### PR TITLE
Uploading more than one endorsement document

### DIFF
--- a/frontend/src/pages/policies/InfoSections/UploadModalEndorsements.tsx
+++ b/frontend/src/pages/policies/InfoSections/UploadModalEndorsements.tsx
@@ -46,14 +46,23 @@ const UploadModal = ({policyNum, setOpenUpload , keyOne}) => {
             if (!documentsJSON) {
                 documentsJSON = {};
             }
-
-            documentsJSON[keyOne] = fileLinks;
+            if (!documentsJSON[keyOne]) {
+                documentsJSON[keyOne] = [];
+            }
+    
+            // Merge existing and new file links, avoiding duplicates
+            documentsJSON[keyOne] = [...new Set([...documentsJSON[keyOne], ...fileLinks])];
+            
+            // documentsJSON[keyOne] = fileLinks;
 
             policyData.set("documents", JSON.stringify(documentsJSON));
+
         } else {
             policyData = new Policies();
             policyData.set("policyNum", policyNum);
-            policyData.set("documents", JSON.stringify({ [keyOne]: fileLinks }));
+            // policyData.set("documents", JSON.stringify({ [keyOne]: fileLinks }));
+            let documentsJSON = { [keyOne]: fileLinks };
+            policyData.set("documents", JSON.stringify(documentsJSON));
         }
 
         await policyData.save();
@@ -160,3 +169,4 @@ const Submit = styled.button`
     }
 
 `
+


### PR DESCRIPTION
While the original code was set up to take multiple links, I believe my changes now ensure that the code appends new file URLs within the existing document structure. Hope this works. 

Also looked into the UploadModelApplication file to get a better idea of how this was done elsewhere in the system.